### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Purpose:
+#   This file defines the code ownership and review responsibilities for the repository.
+#   Owners listed here are automatically requested for review on pull requests that modify files they own.
+#
+# File patterns are followed by one or more GitHub usernames or teams.
+* @andrewjao-edsights @ChuckLangford @hconrad @johnrhampton


### PR DESCRIPTION
This PR adds a CODEOWNERS file to the repo

Refs https://linear.app/edsights/issue/ENG-252/set-up-slack-notifications-for-new-releases-and-deployments

- [x] Have you linked the Linear issue?
- [x] Have you checked if the README or Notion docs need to be updated?
- [x] Have you reviewed if tests need to be added/modified? If not, why?
- [x] Have you confirmed if environment variables need to be added/modified?
- [x] Have you confirmed this change in a deployed environment? If not, why?
- [x] Have you requested a copilot review?

#### Briefly explain the worst scenario that could happen from this pull request

Code owners would not be assigned :suspect: