### PR TITLE
[ENG-1052] added gCloud auth with wl id provider

### DIFF
--- a/.github/actions/setup-gcloud/action.yml
+++ b/.github/actions/setup-gcloud/action.yml
@@ -30,7 +30,3 @@ runs:
       uses: google-github-actions/setup-gcloud@v3
       with:
         install_components: beta
-  post:
-    name: Deauthenticate from Google Cloud
-    if: always()
-    run: gcloud auth revoke --all || echo "No credentials to revoke"


### PR DESCRIPTION
#### Briefly explain the purpose and context of this pull request

Adding gcloud identity provider login. This is the GCP recommended way to authenticate to gCloud via automation

- [x] Have you linked the Linear issue?

- [x] Have you checked if the README or Notion docs need to be updated?

- [x] Have you reviewed if tests need to be added/modified? If not, why?

- [x] Have you confirmed if environment variables need to be added/modified?

- [x] Have you confirmed this change in a deployed environment? If not, why?

- [x] Have you requested a copilot review?

#### Briefly explain the worst scenario that could happen from this pull request

Failure on the gCloud cli authentication
