### PR TITLE
chore: update CODEOWNERS handle @johnrhampton -> @hampsights

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 #   Owners listed here are automatically requested for review on pull requests that modify files they own.
 #
 # File patterns are followed by one or more GitHub usernames or teams.
-* @andrewjao-edsights @ChuckLangford @hconrad @johnrhampton
+* @andrewjao-edsights @ChuckLangford @hconrad @hampsights


### PR DESCRIPTION
Replaces the `@johnrhampton` GitHub handle with the new `@hampsights` handle in CODEOWNERS. No other owners changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)